### PR TITLE
Wrap Traverson's Builder.prototype methods only once

### DIFF
--- a/browser/test/index.html
+++ b/browser/test/index.html
@@ -5,12 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../../node_modules/mocha/mocha.css" />
-    <script src="../../node_modules/angular/angular.js"></script>
-    <script src="../dist/traverson-angular.js"></script>
-  </head>
-  <body>
-    <div id="mocha"></div>
-
     <script src="../../node_modules/mocha/mocha.js"></script>
     <script>
       'use strict';
@@ -18,6 +12,13 @@
       mocha.slow(500)
       mocha.timeout(3000)
     </script>
+    <script src="../../node_modules/angular/angular.js"></script>
+    <script src="../../node_modules/angular-mocks/angular-mocks.js"></script>
+    <script src="../dist/traverson-angular.js"></script>
+  </head>
+  <body>
+    <div id="mocha"></div>
+
 
     <!-- load test suite -->
     <script src="browserified_tests.js"></script>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "angular": "^1.3.4",
+    "angular-mocks": "^1.3.4",
     "angular-sanitize": "^1.3.4",
     "brfs": "^1.1.1",
     "chai": "^1.9.1",

--- a/test/browser_suite.js
+++ b/test/browser_suite.js
@@ -2,3 +2,4 @@ require('./abort_request.js');
 require('./continue.js');
 require('./json_get_resource');
 require('./json_requests.js');
+require('./using_angular_mocks.js');

--- a/test/using_angular_mocks.js
+++ b/test/using_angular_mocks.js
@@ -1,0 +1,69 @@
+/* global angular */
+'use strict';
+
+var chai = require('chai')
+  , expect = chai.expect;
+
+describe('traverson-angular using angular-mocks', function () {
+
+  var rootUri = 'http://api.example.org';
+  var httpBackend, traverson;
+
+  beforeEach(angular.mock.module('traverson'));
+
+  beforeEach(angular.mock.inject(function (_$httpBackend_, _traverson_) {
+    traverson = _traverson_;
+
+    httpBackend = _$httpBackend_;
+    httpBackend.whenGET(rootUri).respond(JSON.stringify({
+      stuff: 'a value',
+      link: rootUri + '/link/to/thing'
+    }));
+    httpBackend.whenGET(rootUri + '/link/to/thing').respond(JSON.stringify({
+      foo: 'bar'
+    }));
+  }));
+
+  afterEach(function () {
+    httpBackend.verifyNoOutstandingExpectation();
+    httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should access the root URI', function (done) {
+    traverson
+      .from(rootUri)
+      .useAngularHttp()
+      .json()
+      .newRequest()
+      .follow()
+      .getResource()
+      .result
+      .then(function (response) {
+        expect(response.stuff).to.equal('a value');
+        done();
+      }, function (error) {
+        done(error);
+      });
+
+    httpBackend.flush();
+  });
+
+  it('should access the link', function (done) {
+    traverson
+      .from(rootUri)
+      .useAngularHttp()
+      .json()
+      .newRequest()
+      .follow('link')
+      .getResource()
+      .result
+      .then(function (response) {
+        expect(response.foo).to.equal('bar');
+        done();
+      }, function (error) {
+        done(error);
+      });
+
+    httpBackend.flush();
+  });
+});

--- a/traverson-angular.js
+++ b/traverson-angular.js
@@ -19,20 +19,20 @@ if (typeof angular !== 'undefined') {
 }
 
 var traversonAngular = ng.module('traverson', []);
+var Builder = traverson._Builder;
+var originalMethods = {
+  get: Builder.prototype.get,
+  getResource: Builder.prototype.getResource,
+  getUrl: Builder.prototype.getUrl,
+  post: Builder.prototype.post,
+  put: Builder.prototype.put,
+  patch: Builder.prototype.patch,
+  delete: Builder.prototype.delete,
+};
 
 traversonAngular.factory('traverson',
   ['$q', '$httpTraversonAdapter',
     function traversonFactory($q, $httpTraversonAdapter) {
-  var Builder = traverson._Builder;
-  var originalMethods = {
-    get: Builder.prototype.get,
-    getResource: Builder.prototype.getResource,
-    getUrl: Builder.prototype.getUrl,
-    post: Builder.prototype.post,
-    put: Builder.prototype.put,
-    patch: Builder.prototype.patch,
-    delete: Builder.prototype.delete,
-  };
 
   function promisify(that, originalMethod, argsArray) {
     var deferred = $q.defer();


### PR DESCRIPTION
Fixes #12 by moving the `originalMethods` initialisation outside the factory method. Added spec using angular-mocks, the 2nd test case fails with a timeout without the code change.